### PR TITLE
setChannelByArray proposal

### DIFF
--- a/TeensyDmx.cpp
+++ b/TeensyDmx.cpp
@@ -237,6 +237,23 @@ void TeensyDmx::setChannels(
     }
 }
 
+// I am sure there is some code problems here but I wanted to suggest this feature for you to implement better than I can.
+void TeensyDmx::setChannelByArray(const uint8_t* values[]){
+    uint16_t currentAddress = 0;
+    while (currentAddress < DMX_BUFFER_SIZE) {
+        m_activeBuffer[currentAddress] = 0;
+        ++currentAddress;
+    }
+    for (uint16_t i = 0; i < 512; ++i) {
+        m_activeBuffer[currentAddress] = values[i];
+        ++currentAddress;
+    }
+    while (currentAddress < DMX_BUFFER_SIZE) {
+        m_activeBuffer[currentAddress] = 0;
+        ++currentAddress;
+    }
+}
+
 void TeensyDmx::nextTx()
 {
     if (m_state == State::BREAK) {

--- a/TeensyDmx.h
+++ b/TeensyDmx.h
@@ -129,6 +129,8 @@ class TeensyDmx
     {
         setChannels(startAddress - 1, values, length);
     }
+    //setChannelByArray corresponding to my .cpp edit
+    void setChannelByArray(const uint8_t* values[])
 
   private:
     TeensyDmx(const TeensyDmx&);


### PR DESCRIPTION
I am sure I implemented this incredibly poorly but I think it sort of demonstrates what I would love to see from this library.  I am putting most of my number crunching power (that already drives an interface anyway) into an external machine (smart phone) that sends data to the Teensy through BLE.  So, a simple way to parse an array (with a required 512 channel input?) into straight DMX signal without having to break up my channel-setting function calls might prove useful.  

It also allows multiple channels to be changed to different levels in one fell swoop.  